### PR TITLE
feat: cta de compra nos card de produto

### DIFF
--- a/components/product/AddToCartButton.tsx
+++ b/components/product/AddToCartButton.tsx
@@ -53,15 +53,12 @@ const onLoad = (id: string) => {
     const checkbox = container?.querySelector<HTMLInputElement>(
       'input[type="checkbox"]',
     );
-    const input = container?.querySelector<HTMLInputElement>(
-      'input[type="number"]',
-    );
+
     const itemID = container?.getAttribute("data-item-id")!;
     const quantity = sdk.getQuantity(itemID) || 0;
-    if (!input || !checkbox) {
+    if (!checkbox) {
       return;
     }
-    input.value = quantity.toString();
     checkbox.checked = quantity > 0;
     // enable interactivity
     container
@@ -136,9 +133,12 @@ function AddToCartButton(props: Props) {
 
       <button
         disabled
-        class={clx("flex-grow", _class?.toString())}
+        class={clx("flex-grow group disabled:bg-primary disabled:opacity-80", _class?.toString())}
         hx-on:click={useScript(onClick)}
       >
+        <span className="group-disabled:flex hidden loading loading-spinner loading-md"></span>
+        <div class={"group-disabled:hidden flex justify-center items-center gap-2"  }>
+
         {props.ctaText ?? "COMPRAR AGORA"}
         <svg
           class="w-4 h-4 md:w-8 md:h-8 lg:w-5 lg:h-5 xl:w-8 xl:h-8"
@@ -147,22 +147,23 @@ function AddToCartButton(props: Props) {
           viewBox="0 0 32 32"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-        >
+          >
           <path
             d="M8 2.667 4 8v18.667a2.667 2.667 0 0 0 2.667 2.666h18.666A2.667 2.667 0 0 0 28 26.667V8l-4-5.333zM4 8h24"
             stroke="#fff"
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
-          />
+            />
           <path
             d="M21.333 13.333a5.333 5.333 0 1 1-10.666 0"
             stroke="#fff"
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
-          />
+            />
         </svg>
+      </div>
       </button>
 
       {/* Quantity Input */}

--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -268,31 +268,30 @@ function ProductCard({
           </div>
         )}
         {inStock ? (
-          // <AddToCartButton
-          //   product={product}
-          //   seller={seller}
-          //   item={item}
-          //   ctaText="ADICIONAR À SACOLA"
-          //   class={`${isFeatured ? "px-1.5 md:text-sm mt-2.5" : ""} ${
-          //     clx(
-          //       "btn uppercase",
-          //       "btn-outline rounded-lg border-none px-0 no-animation w-full",
-          //       "bg-primary text-white h-14 font-semibold  md:text-sm lg:text-xs xl:text-sm text-xs  flex-nowrap",
-          //       "hover:bg-primary",
-          //     )
-          //   }`}
-          // />
-          <a
-            href={relativeUrl}
-            class={`${clx(
+          <AddToCartButton
+            product={product}
+            seller={seller}
+            item={item}
+            ctaText="ADICIONAR À SACOLA"
+            class={`${isFeatured ? "px-1.5 md:text-sm mt-2.5" : ""} ${clx(
               "btn uppercase",
               "btn-outline rounded-lg border-none px-0 no-animation w-full",
               "bg-primary text-white h-14 font-semibold  md:text-sm lg:text-xs xl:text-sm text-xs  flex-nowrap",
-              "hover:bg-primary"
-            )}`}
-          >
-            Ver mais
-          </a>
+              "hover:bg-primary",
+            )
+              }`}
+          />
+          // <a
+          //   href={relativeUrl}
+          //   class={`${clx(
+          //     "btn uppercase",
+          //     "btn-outline rounded-lg border-none px-0 no-animation w-full",
+          //     "bg-primary text-white h-14 font-semibold  md:text-sm lg:text-xs xl:text-sm text-xs  flex-nowrap",
+          //     "hover:bg-primary"
+          //   )}`}
+          // >
+          //   Ver mais
+          // </a>
         ) : (
           <a
             href={relativeUrl}
@@ -307,7 +306,7 @@ function ProductCard({
           </a>
         )}
       </div>
-    </div>
+    </div >
   );
 }
 

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -2576,6 +2576,9 @@ details.collapse summary::-webkit-details-marker {
 .loading-sm {
   width: 1.25rem;
 }
+.loading-md {
+  width: 1.5rem;
+}
 :where(.menu li:empty) {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-bc,oklch(var(--bc)/var(--tw-bg-opacity)));
@@ -6931,12 +6934,21 @@ flex-grow-1 {
   background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity)));
 }
 
+.disabled\:bg-primary:disabled {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-p,oklch(var(--p)/var(--tw-bg-opacity)));
+}
+
 .disabled\:bg-transparent:disabled {
   background-color: transparent;
 }
 
 .disabled\:opacity-100:disabled {
   opacity: 1;
+}
+
+.disabled\:opacity-80:disabled {
+  opacity: 0.8;
 }
 
 .group[open] .group-open\:border-b-\[4px\] {
@@ -6990,6 +7002,14 @@ flex-grow-1 {
 
 .group:hover .group-hover\:opacity-100 {
   opacity: 1;
+}
+
+.group:disabled .group-disabled\:flex {
+  display: flex;
+}
+
+.group:disabled .group-disabled\:hidden {
+  display: none;
 }
 
 .group:disabled .group-disabled\:border-orange-300 {


### PR DESCRIPTION
 ## problema:
 Cta de compra não funcionava nos cards de produtos, PLP e Vitrines
 
 ## Resolução:
 Foi implementado a funcionalidade de compra nos cta dos cards de produto:

Enquando a pagina é carregada ou um produto é adicionado a sacola aparece um loanding nos ctas como mostra a imagem abaixo
![image](https://github.com/user-attachments/assets/e619879a-2c31-4139-9be1-5849243d0604)
